### PR TITLE
Update .gitignore file.

### DIFF
--- a/Firmware-Code/GPIO-Driver/.gitignore
+++ b/Firmware-Code/GPIO-Driver/.gitignore
@@ -1,2 +1,5 @@
 /Debug/*
 !Debug/Makefile
+!/Debug/GPIO_Driver_Debug_library.ld
+!/Debug/GPIO_Driver_Debug_memory.ld
+!Debug/GPIO_Driver_Debug.ld


### PR DESCRIPTION
Update .gitignore to make  linker ld files visible.